### PR TITLE
feat(bench): Control iterations from bench constructor

### DIFF
--- a/docs/articles/about-benchmarking.md
+++ b/docs/articles/about-benchmarking.md
@@ -20,3 +20,4 @@ A micro benchmark is simply a function you supply, that will be run for a number
 
 Instantiate the `Bench` class to create a benchmark suite. use `bench.group` to group bench cases and add headers. Use `bench.add` to register individual benchmarks.
 
+By default, each test case now runs a single iteration before reporting results. You can control this by passing an `iterations` option (or `minIterations` for backwards compatibility) to the `Bench` constructor or individual test cases. Increasing the iteration count will re-run the benchmark that many times and aggregate the results, at the cost of longer total execution time.

--- a/modules/bench/src/bench.ts
+++ b/modules/bench/src/bench.ts
@@ -28,6 +28,8 @@ export type BenchProps = {
   delay?: number;
   /** Increase if OK to let slow benchmarks take long time, potentially produces more stable results */
   minIterations?: number;
+  /** Number of iterations to run for each benchmark test */
+  iterations?: number;
 };
 
 export type BenchTestFunction = <T>(testArgs?: T) => T | Promise<T>;
@@ -49,6 +51,8 @@ export type BenchTestCaseProps = {
   delay?: number;
   /** Increase if OK to let slow benchmarks take long time, potentially produces more stable results */
   minIterations?: number;
+  /** Number of iterations to run for each benchmark test */
+  iterations?: number;
   multiplier?: number;
   unit?: string;
   _throughput?: number;
@@ -99,6 +103,8 @@ type BenchTestCase = {
   delay: number;
   /** Increase if OK to let slow benchmarks take long time, potentially produces more stable results */
   minIterations: number;
+  /** Number of iterations to run for each benchmark test */
+  iterations: number;
   multiplier: number;
   unit: string;
   _throughput: number;
@@ -112,7 +118,8 @@ const DEFAULT_BENCH_OPTIONS: Required<BenchProps> = {
   log: undefined!,
   time: 80,
   delay: 5,
-  minIterations: 3
+  minIterations: 1,
+  iterations: 1
 };
 
 const DEFAULT_BENCH_TEST_CASE: BenchTestCase = {
@@ -126,6 +133,7 @@ const DEFAULT_BENCH_TEST_CASE: BenchTestCase = {
   once: false,
   time: 0,
   minIterations: 1,
+  iterations: 1,
   multiplier: 1, // multiplier per test case
   unit: '',
   delay: 0,
@@ -147,7 +155,7 @@ export class Bench {
 
   constructor(props: BenchProps = {}) {
     this.props = {...DEFAULT_BENCH_OPTIONS, ...props};
-    const {id, time, delay, minIterations} = this.props;
+    const {id, time, delay, minIterations, iterations} = this.props;
 
     let log = this.props.log;
     if (!log) {
@@ -156,7 +164,7 @@ export class Bench {
     }
 
     this.id = id;
-    this.props = {id, log, time, delay, minIterations};
+    this.props = {id, log, time, delay, minIterations, iterations};
     autobind(this);
     Object.seal(this);
   }
@@ -374,9 +382,9 @@ async function runBenchTestCaseAsync(testCase: BenchTestCase) {
   let totalTime = 0;
   let totalIterations = 0;
 
-  const minIterations: number = testCase.minIterations || 1;
+  const iterationCount: number = testCase.iterations ?? testCase.minIterations ?? 1;
 
-  for (let i = 0; i < minIterations; i++) {
+  for (let i = 0; i < iterationCount; i++) {
     let time;
     let iterations;
     // Runs "testCase._throughput" parallel testCase cases

--- a/modules/bench/test/bench.spec.ts
+++ b/modules/bench/test/bench.spec.ts
@@ -34,3 +34,23 @@ test('Bench#run', (t) => {
   t.ok(suite instanceof Bench, 'suite created successfully');
   suite.run().then(() => t.end());
 });
+
+test('Bench#iterations option', (t) => {
+  const suite = new Bench({
+    id: 'iteration-control',
+    iterations: 2,
+    time: 1,
+    log: () => {}
+  });
+
+  let callCount = 0;
+
+  suite.addAsync('respects iteration count', {_throughput: 1}, async () => {
+    callCount++;
+  });
+
+  suite.run().then(() => {
+    t.equals(callCount, 2, 'runs configured number of iterations');
+    t.end();
+  });
+});


### PR DESCRIPTION
The benchmark suites run each benchmark many times. While this does offer a marginal increase in repeatability, it has made benchmarks usage impractically slow and in most repos the benchmarks have now gone stale.

This adds an iterations parameter to the Bench constructor that defaults to 1.