### PR TITLE
docs: Fix documentation typos and formatting

### DIFF
--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -2,7 +2,7 @@
 
 ## IDEAS
 
-* Save probes to local storage and comare runs
+* Save probes to local storage and compare runs
 * Read options from node command line
 * Read options from URL query string (when hash is used by app router)
 * Detect production builds and automatically disable

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,20 +6,20 @@ A collection of JavaScript front-end debugging tools provided as a set of separa
 | --- | --- |
 | **`@probe.gl/log`**    | A JavaScript logging library focused on facilitating debugging and performance instrumentation of front-end applications. |
 | **`@probe.gl/env`**    | Basic environment detection (Browser, Node, Electron etc). | 
-| **`@probe.gl/stats`**  | A minimal bag of performance related stats that applications or frameworks can populate. | 
-| **`@probe.gl/stats-widget`** | An HTML widget that helps applications display the contests of `@probe.gl/stats` objects. | 
+| **`@probe.gl/stats`**  | A minimal bag of performance-related stats that applications or frameworks can populate. |
+| **`@probe.gl/stats-widget`** | An HTML widget that helps applications display the contents of `@probe.gl/stats` objects. |
 | **`@probe.gl/bench`**  | A benchmark rig to help measure and track regressions of critical functions. |
 | **`@probe.gl/react-bench`**  | A React component that displays the output of `@probe.gl/bench`. |
 | **`@probe.gl/test-utils`**   | Test "Drivers" for running automated browser testing from Node via `puppeteer`. |
 
 ## Comparison with other Logging Solutions
 
-proble.gl's focus on debugging and performance instrumentation of front-end applications has lead to different design choices and priorities compared with logging libraries that are designed for facilitating logging of production code in back-end services. Those libraries are often focused on integrating with various logging backends (log to file, log to server, etc) and not on integrating with the browser console and the front-end debugging workflow.
+probe.gl's focus on debugging and performance instrumentation of front-end applications has led to different design choices and priorities compared with logging libraries that are designed for facilitating logging of production code in back-end services. Those libraries are often focused on integrating with various logging backends (log to file, log to server, etc.) and not on integrating with the browser console and the front-end debugging workflow.
 
 
 ## Features
 
-* **Off by default** - probe.gl makes efforts to have a minimal performance footprint when not enable, to let you consider leaving your probes switched off in production code.
+* **Off by default** - probe.gl makes efforts to have a minimal performance footprint when not enabled, to let you consider leaving your probes switched off in production code.
 * **Lightweight** - probe.gl is designed to have a small impact on application bundle size and to avoid dependencies on other modules.
 
 
@@ -57,15 +57,15 @@ probe.gl offers a basic persistent configuration system:
 
 ### Debug Features
 
-debug related facilities, such as console log interception, global context in debugger etc.
+Debug-related facilities, such as console log interception and access to a global context in the debugger.
 
 
 ### Benchmarking Support
 
 In addition to in-app profiling, probe also supports a simple benchmarking rig
 
-* **Benchmark Suite** - function to run a suite of functions and collect data
-* **Persist and Compare Benchmarks** -
+* **Benchmark Suite** - Functions to run a suite of benchmarks and collect data.
+* **Persist and Compare Benchmarks** - Persist results and compare runs to track regressions.
 
 
 ## History

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,17 +2,16 @@
 
 We are still iterating on probe.gl. Here are some of the ideas, in very rough form...
 
-- **In-memory log:** Instead of, or in addition to, logging to the console, `Probe.probe` now saves to an internal array of log messages. This allows you to turn console output off and do post-facto reporting or visualization.
+- **In-memory log:** Instead of, or in addition to, logging to the console, `Probe.probe` can save to an internal array of log messages. This allows you to turn console output off and do post-facto reporting or visualization.
 
 - **Persistent settings and saved logs** - Local storage configuration now allows for persistent configuration (including enable/disable) across browser sessions, and makes it easier to have Probe disabled (or enabled, for developers) in production. This also makes it easy to set additional development flags like `isNewFeatureEnabled`. Usage via the JS console:
 ```
 Probe.enable().configure({level: 2, useMyDevFeature: true});
 ```
 
-- **Better Console groups** - Probe.groups allows independently time execution of parallel activities, using console groups to organize the output.
+- **Better console groups** - `Probe.groups` allows independent timing of parallel activities, using console groups to organize the output.
 
-- **Duration:** Including `start` and `end` in the metadata object allows Probe
-o calculate duration between calls using the same `name`:
+- **Duration:** Including `start` and `end` in the metadata object allows Probe to calculate duration between calls using the same `name`:
 ```
 Probe.probe('long_process', {start: true});
 doLongProcess();

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -4,25 +4,25 @@
 
 
 **ES Modules**
-- probe.gl is used to test transition to ES Modules for all the vis.gl frameworks including deck.gl.
-- You are welcome report any issues in the probe.gl repo.
+- probe.gl is used to test the transition to ES Modules for all the vis.gl frameworks including deck.gl.
+- You are welcome to report any issues in the probe.gl repo.
 
 **`@probe.gl/bench`**
-- `Bench.add()` / `Bench.addAsync()` - The number of overloads has been reduced so some existing benchmark suites may need to be updated. When specifying priority and options, simply supply a property object instead of position arguments.
+- `Bench.add()` / `Bench.addAsync()` - The number of overloads has been reduced so some existing benchmark suites may need to be updated. When specifying priority and options, simply supply a property object instead of positional arguments.
 - Custom logging
     - the type of each `LogEntry` is now controlled by the `type` field instead of the `entry` field.
     - For `LogEntry.type`, the LOG_ENTRY export is removed in favor of simple string constants.
 
 **`probe.gl`**
-- The `probe.gl` "umbrella" module is no longer available as of 4.0. Simply replace `probe.gl` with the scoped `@probe.gl/...` modules you are actually using.
+- The `probe.gl` "umbrella" module is no longer available as of 4.0. Replace `probe.gl` with the scoped `@probe.gl/...` modules you are actually using.
 
 ## Upgrading to v3.5 
 
-- From v3.5, the `probe.gl` module is being deprecated in favor of importing sub modules `@probe.gl/...`. 
-- The `probe.gl` module may be removed in probe.gl v4.0, but for backwards compatibility, this module will still be present in v3.x.
+- From v3.5, the `probe.gl` module is being deprecated in favor of importing submodules `@probe.gl/...`.
+- The `probe.gl` module may be removed in probe.gl v4.0, but for backwards compatibility this module will still be present in v3.x.
 - `probe.gl` no longer contains any code, it just re-exports from `@probe.gl/env`, `@probe.gl/log`, `@probe.gl/stats`.
 
 To upgrade:
-- `import 'probe.gl` should be replaced with `import '@probe.gl/env'`, `import '@probe.gl/log'` and/or `import '@probe.gl/stats'` (depending on which imports you are using.).
+- `import 'probe.gl'` should be replaced with `import '@probe.gl/env'`, `import '@probe.gl/log'` and/or `import '@probe.gl/stats'` (depending on which imports you are using).
 - Update your `package.json` file(s) to install the submodules instead of the main module.
-- The `import 'probe.gl/env` subdirectory import should be replaced with `import '@probe.gl/env'` (note the leading `@` sign). The subdirectory import is occasionally causing problems with bundlers and the submodule import should be more robust.
+- The `import 'probe.gl/env'` subdirectory import should be replaced with `import '@probe.gl/env'` (note the leading `@` sign). The subdirectory import occasionally causes problems with bundlers and the submodule import should be more robust.


### PR DESCRIPTION
## Summary
- correct typos and improve phrasing in the main documentation overview
- clarify roadmap notes and upgrade guidance for probe.gl modules
- fix spelling in developer roadmap notes

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694308f01d3883289d96f5abdce44cb8)